### PR TITLE
Fixed maven uris

### DIFF
--- a/androidDeps.nix
+++ b/androidDeps.nix
@@ -466,7 +466,7 @@
   { artifactId = "apache";
     groupId = "org.apache";
     version = "13";
-    repo = "https://central.maven.org/maven2/";
+    repo = "https://repo1.maven.org/maven2/";
     jarSha256 = null;
     pomSha256 = "ff513db0361fd41237bef4784968bc15aae478d4ec0a9496f811072ccaf3841d";
     aarSha256 = null; }
@@ -474,7 +474,7 @@
   { artifactId = "apache";
     groupId = "org.apache";
     version = "4";
-    repo = "https://central.maven.org/maven2/";
+    repo = "https://repo1.maven.org/maven2/";
     jarSha256 = null;
     pomSha256 = "9e9323a26ba8eb2394efef0c96d31b70df570808630dc147cab1e73541cc5194";
     aarSha256 = null; }


### PR DESCRIPTION
central.maven.org no longer seems to be available. 